### PR TITLE
better results for glamor 

### DIFF
--- a/src/classes-overload-test/cases/glamor.js
+++ b/src/classes-overload-test/cases/glamor.js
@@ -1,5 +1,5 @@
 import { renderStatic } from 'glamor/server';
-import { style, flush } from 'glamor';
+import { style } from 'glamor';
 import { containerStyle, buttonStyles } from '../styles';
 import { renderHtml, renderBody } from '../render';
 
@@ -11,7 +11,6 @@ export const glamorCase = (caseName) => {
         renderBody(caseName, style(containerStyle), getButtonClassName)
     );
 
-    flush();
 
     return renderHtml(css, html);
 };

--- a/src/nested-test/cases/glamor.js
+++ b/src/nested-test/cases/glamor.js
@@ -1,5 +1,5 @@
 import { renderStatic } from 'glamor/server';
-import { style, flush } from 'glamor';
+import { style } from 'glamor';
 import { createContainerStyle, createButtonStyle } from '../styles';
 import { renderHtml, renderBody } from '../render';
 
@@ -7,8 +7,6 @@ export const glamorCase = (caseName) => {
     const { html, css } = renderStatic(() =>
         renderBody(caseName, style(createContainerStyle()), style(createButtonStyle()))
     );
-
-    flush();
 
     return renderHtml(css, html);
 };

--- a/src/nested-test/cases/glamor.js
+++ b/src/nested-test/cases/glamor.js
@@ -3,9 +3,12 @@ import { style } from 'glamor';
 import { createContainerStyle, createButtonStyle } from '../styles';
 import { renderHtml, renderBody } from '../render';
 
+const containerStyle = createContainerStyle()
+const buttonStyle = createButtonStyle()
+
 export const glamorCase = (caseName) => {
     const { html, css } = renderStatic(() =>
-        renderBody(caseName, style(createContainerStyle()), style(createButtonStyle()))
+        renderBody(caseName, style(containerStyle), style(buttonStyle))
     );
 
     return renderHtml(css, html);

--- a/src/simple-test/cases/glamor.js
+++ b/src/simple-test/cases/glamor.js
@@ -1,5 +1,5 @@
 import { renderStatic } from 'glamor/server';
-import { style, flush } from 'glamor';
+import { style } from 'glamor';
 import { containerStyle, buttonStyle, notUsedStyle } from '../styles';
 import { renderHtml, renderBody } from '../render';
 
@@ -7,8 +7,6 @@ export const glamorCase = (caseName) => {
     const { html, css } = renderStatic(() =>
         renderBody(caseName, style(containerStyle), style(buttonStyle), style(notUsedStyle))
     );
-
-    flush();
 
     return renderHtml(css, html);
 };

--- a/src/style-overload-test/cases/glamor.js
+++ b/src/style-overload-test/cases/glamor.js
@@ -1,5 +1,5 @@
 import { renderStatic } from 'glamor/server';
-import { style, flush } from 'glamor';
+import { style } from 'glamor';
 import { containerStyle, buttonStyles } from '../styles';
 import { renderHtml, renderBody } from '../render';
 
@@ -10,8 +10,6 @@ export const glamorCase = (caseName) => {
     const { html, css } = renderStatic(() =>
         renderBody(caseName, style(containerStyle), getButtonClassName)
     );
-
-    flush();
 
     return renderHtml(css, html);
 };


### PR DESCRIPTION
`flush()` is meant as a helper for tests, and is never used in production. the current tests were (unrealistically) setting up and destroying the caches on every run. This PR removes that behavior, resulting in *much* better results for glamor. 

PS- `src/utilities.js::getSizeResults` was throwing errors wrt the free-style tests, used this substitution to work around it 
```diff
export const getSizeResults = testCases => (
    Object.keys(testCases).map((caseName) => {
-        const result = testCases[caseName].result;
+        const result = testCases[caseName].result || {};
        return {
            caseName,
-            size: result.length,
+            size: result.length || 0,
-            gzippedSize: gzipSize.sync(result),
+            gzippedSize: result.length ? gzipSize.sync(result) : 0,
        };
    })
);

``` 